### PR TITLE
Update invite email template

### DIFF
--- a/uaainvite/templates/email/body.html
+++ b/uaainvite/templates/email/body.html
@@ -22,7 +22,7 @@
         <p>
         <ol>
             <li>
-                To log into cloud.gov, which requires multi-factor authentication, first install a mobile application that generates time-based one-time passwords.  We recommend installing either <a href="https://support.google.com/accounts/answer/1066447?hl=en">Google Authenticator</a> or <a href="https://www.authy.com/app/mobile">Authy</a> on your mobile device. The registration process will give you instructions for using it.
+                To log into cloud.gov, which requires multi-factor authentication, first install a mobile application that generates time-based one-time passwords.  We recommend installing either <a href="https://support.google.com/accounts/answer/1066447?hl=en">Google Authenticator</a> or <a href="https://www.authy.com/app/mobile">Authy</a> on your mobile device. In your next step, the cloud.gov registration process will give you instructions for using it.
             </li>
             <li>
                 <a href="{{invite.inviteLink}}">Accept your invite</a> to continue the registration process.

--- a/uaainvite/templates/email/body.html
+++ b/uaainvite/templates/email/body.html
@@ -7,71 +7,35 @@
     <body>
         <p>Hello!</p>
         <p>
-            admin has invited you to join the
-            closed pilot of
-            <a href="https://cloud.gov">{{branding.company_name}}</a>
+            You've been invited to join 
+            <a href="https://cloud.gov">{{branding.company_name}}</a>.
         </p>
         <p>
-            {{branding.company_name}} is a new service under
-            development by 18F intended to help
-            federal teams focus on creating quality services securely hosted in the cloud,
-            and assist in getting Authority to Operate (ATO) in record time.
+            {{branding.company_name}} is a service by 18F intended to help
+            federal teams create and deliver quality digital services securely hosted in the cloud.
             {{branding.company_name}} is currently in
             <a href="https://18f.gsa.gov/dashboard/">alpha state</a>
-            and under active development. We'll be asking for your feedback and making
-            improvements on a regular basis.
+            and under active development. We'll ask for your feedback and make
+            improvements frequently.
         </p>
+        <strong>Your next steps</strong>
         <p>
-            To this point, {{branding.company_name}} has been an
-            internal-facing service for 18F,
-            so please have patience as we improve the on-boarding and support experience
-            for people from other agencies, and correct documentation which may be
-            18F-specific.
-        </p>
-        <p>
-        </p>
-        <strong>Here's what happens next</strong>
-        <p>
-        <ul>
+        <ol>
             <li>
-                In order to perform multi-factor authentication with the cloud.gov provider,
-                you will need an authentication application that generates time-based on-time
-                passwords.  We recommend either
-                <a href="https://support.google.com/accounts/answer/1066447?hl=en">Google Authenticator</a> or
-                <a href="https://www.authy.com/app/mobile">Authy</a>.
-                Download either app to your mobile device. You will be presented with instructions
-                on how to store the cloud.gov key in your application during the registration process.
+                To log into cloud.gov, which requires multi-factor authentication, first install a mobile application that generates time-based one-time passwords.  We recommend installing either <a href="https://support.google.com/accounts/answer/1066447?hl=en">Google Authenticator</a> or <a href="https://www.authy.com/app/mobile">Authy</a> on your mobile device. The registration process will give you instructions for using it.
             </li>
             <li>
-                <a href="{{invite.inviteLink}}">Accept Invite</a>
-                to continue the registration process.
+                <a href="{{invite.inviteLink}}">Accept your invite</a> to continue the registration process.
             </li>
             <li>
-                You should download the CLI tool to start using the platform according to
-                the <a href="https://docs.cloud.gov/getting-started/setup/">Getting Started - Setup</a> page.
+                After you register and log in, review the <a href="https://cloud.gov/docs/getting-started/accounts/#using-your-account-responsibly">acceptable uses and rules of behavior</a>. Then <a href="https://cloud.gov/docs/getting-started/setup/">set up your access and get started</a>.
             </li>
-            <li>
-                If you log in immediately, you may not see any orgs or spaces to which
-                you have access. It might take up to 5 minutes to provision your sandbox
-                space.
-            </li>
-        </ul>
-        </p>
-        <p>
-            That's it! You're ready to use the platform. The platform is well-documented
-            at <a href="https://docs.cloudfoundry.org">https://docs.cloudfoundry.org</a>,
-            and documentation about {{branding.company_name}} in particular is
-            located <a href="https://docs.cloud.gov">here</a>.
-        </p>
-        <p>
-            You'll probably want to try deploying an application to see how it works.
-            We have some sample applications available
-            <a href="https://github.com/18F/cf-hello-worlds">here</a>.
+        </ol>
         </p>
         <p>
             If you run into problems or have any questions,
-            please send us an
-            <a href="mailto:cloud-gov-support@gsa.gov">e-mail</a>.
+            please email us at 
+            <a href="mailto:cloud-gov-support@gsa.gov">cloud-gov-support@gsa.gov</a>.
         </p>
         <p>
             Thank you,<br />


### PR DESCRIPTION
Followup from https://github.com/18F/cg-uaa-invite/pull/27 that makes a few incremental changes:

* Update first sentence to remove potentially-confusing "admin" term. Ideally we should find a replacement that isn't passive voice, but eh...incremental improvements.
* Trim "closed pilot", "new service", "has been an internal-facing service for 18F", etc., since it's not that closed or new anymore!
* "Here's what happens next" -> "Your next steps", to speak to the reader more directly.
* Numbered list instead of unordered list, since a person should follow the three steps in order.
* Add specific next steps and avoid duplicating info in the intro docs.