### PR TITLE
Reinvite fix

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,17 @@
 [tox]
-envlist = py34,flake8
+envlist = py34,flake8,report
 
 [testenv]
-commands=python setup.py test
+commands =
+  coverage erase
+  coverage run -a setup.py test
+deps =
+  coverage
+
+[testenv:report]
+commands =
+  coverage report --include="*uaaextras*" --omit="*tests*"
+  coverage html --include="*uaaextras*" --omit="*tests*"
 
 [testenv:flake8]
 deps = flake8

--- a/uaaextras/clients/uaa.py
+++ b/uaaextras/clients/uaa.py
@@ -307,3 +307,42 @@ class UAAClient(object):
                 return True
 
         return False
+
+    def does_origin_user_exist(self, client_id, client_secret, username, origin):
+        """ Checks to see if a user exists with a given origin
+        Args:
+            client_id: The oauth client id that this code was generated for
+            client_secret: The secret for the client_id above
+            user_id: the username to check
+            origin: the UAA origin
+        Raises:
+            UAAError: there was an error changing the password
+
+        Returns:
+            boolean: user exists or not
+        """
+        token = self._request(
+            '/oauth/token',
+            'POST',
+            params={
+                'grant_type': 'client_credentials',
+                'response_type': 'token'
+            },
+            auth=HTTPBasicAuth(client_id, client_secret)
+        )['access_token']
+        if token:
+            userList = self._request(
+                '/Users',
+                'GET',
+                params={
+                    'filter': 'userName eq "{0}" and origin eq "{1}"'.format(username, origin),
+                    'count': 1
+                },
+                headers={
+                    'Authorization': 'Bearer ' + token
+                }
+            )
+            if len(userList['resources']) > 0:
+                return True
+
+        return False

--- a/uaaextras/webapp.py
+++ b/uaaextras/webapp.py
@@ -27,8 +27,8 @@ CONFIG_KEYS = {
     'SMTP_USER': None,
     'SMTP_PASS': None,
     'BRANDING_COMPANY_NAME': 'Cloud Foundry',
-    'IDP_PROVIDER_ORIGIN': 'https://idp.bosh-lite.com',
-    'IDP_PROVIDER_URL': 'my.idp.com'
+    'IDP_PROVIDER_ORIGIN': 'idp.com',
+    'IDP_PROVIDER_URL': 'https://idp.bosh-lite.com'
 }
 
 EXPIRATION_TIME_IN_SECONDS = 43200
@@ -294,6 +294,14 @@ def create_app(env=os.environ):
 
         # email is good, lets invite them
         try:
+            if g.uaac.does_origin_user_exist(
+                    app.config['UAA_CLIENT_ID'],
+                    app.config['UAA_CLIENT_SECRET'],
+                    email,
+                    app.config['IDP_PROVIDER_ORIGIN']):
+                flash('User already has a valid account.')
+                return render_template('invite.html')
+
             redirect_uri = os.path.join(request.url_root, 'oauth', 'login')
             logging.info('redirect for invite: {0}'.format(redirect_uri))
             invite = g.uaac.invite_users(email, redirect_uri)


### PR DESCRIPTION
This fixes an issue where if we invite a user, they accept the invite, get converted to an IdP user, and then someone invites them again, they now have two accounts, one for the IdP, one for UAA local.

See: https://gsa-tts.slack.com/archives/cloud-gov-atlas/p1480523380011130

@rogeruiz @cnelson 