### PR TITLE
Reduce memory requirements for invite redirect app

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -4,6 +4,7 @@ applications:
   host: invite
   buildpack: staticfile_buildpack
   path: redirect
+  memory: 64M
   env:
     TARGET_DOMAIN: account.fr-stage.cloud.gov/invite
 - name: uaaextra


### PR DESCRIPTION
As it's clearly not using 512M:

     #0   running   2017-02-03 07:53:16 AM   0.0%   8.5M of 512M   7M of 1G