### PR TITLE
Adding a missing space to error message + tip for errors

### DIFF
--- a/uaaextras/webapp.py
+++ b/uaaextras/webapp.py
@@ -457,7 +457,7 @@ def create_app(env=os.environ):
             valid_gov_email = True
         if not valid_gov_email:
             flash('This does not seem to be a U.S. federal government email address. '
-                  'Self-service invitations are only offered for U.S.federal government email addresses.')
+                  'Self-service invitations are only offered for U.S. federal government email addresses.')
             return render_template('signup.html')
 
         # email is good, lets invite them

--- a/uaaextras/webapp.py
+++ b/uaaextras/webapp.py
@@ -457,7 +457,9 @@ def create_app(env=os.environ):
             valid_gov_email = True
         if not valid_gov_email:
             flash('This does not seem to be a U.S. federal government email address. '
-                  'Self-service invitations are only offered for U.S. federal government email addresses.')
+                  'Self-service invitations are only offered for U.S. federal government email addresses. '
+                  'If you do have a U.S. federal government email address, email us at '
+                  'cloud-gov-inquiries@gsa.gov to let us know to whitelist your domain.')
             return render_template('signup.html')
 
         # email is good, lets invite them


### PR DESCRIPTION
U.S.federal -> "U.S. federal"

Also: "If you do have a U.S. federal government email address, email us at cloud-gov-inquiries@gsa.gov to let us know to whitelist your domain."