### PR TITLE
Note that invitations expire

### DIFF
--- a/uaaextras/templates/email/body.html
+++ b/uaaextras/templates/email/body.html
@@ -17,7 +17,7 @@
         <p>
         <ol>
             <li>
-            <b>Accept the invitation</b> - <a href="{{verification_url}}">Accept your invite</a> to continue the registration process. You can also copy the URL below and paste it into your browser's address bar:
+            <b>Accept the invitation</b> - <a href="{{verification_url}}">Accept your invite</a> to continue the registration process. (The invitation will expire after 24 hours.) You can also copy the URL below and paste it into your browser's address bar:
             <br />
             {{verification_url}}
             </li>


### PR DESCRIPTION
We sometimes get support emails from people who are surprised that their invitation has expired, so here's a tiny hint to encourage them to click the link when they get it.