### PR TITLE
Tell people to log in before changing password

### DIFF
--- a/uaaextras/templates/email/body-expiring-password.html
+++ b/uaaextras/templates/email/body-expiring-password.html
@@ -11,7 +11,7 @@
             will expire in {{password.daysUntilExpiration}} days.
         </p>
         <p>
-            Please <a href="https://login.fr.cloud.gov/login">log in</a> with your current password</a> and then <a href="{{password.changeLink}}">change your password</a>.
+            Please <a href="{{password.loginLink}}">log in</a> with your current password</a> and then <a href="{{password.changeLink}}">change your password</a>.
         </p>
         <p>
             If you run into problems or have any questions,

--- a/uaaextras/templates/email/body-expiring-password.html
+++ b/uaaextras/templates/email/body-expiring-password.html
@@ -11,7 +11,7 @@
             will expire in {{password.daysUntilExpiration}} days.
         </p>
         <p>
-            Please <a href="{{password.changeLink}}">change your password</a> soon, before it expires.
+            Please <a href="https://login.fr.cloud.gov/login">log in</a> with your current password</a> and then <a href="{{password.changeLink}}">change your password</a>.
         </p>
         <p>
             If you run into problems or have any questions,

--- a/uaaextras/templates/email/body-password.html
+++ b/uaaextras/templates/email/body-password.html
@@ -15,10 +15,10 @@
         <p>
         <ol>
             <li>
-                <a href="{{reset.verifyLink}}">Verify your email address</a>, and follow those instructions to generate your temporary password. Save your generated password before closing the window.
+                <a href="{{reset.verifyLink}}">Verify your email address</a>, and follow those instructions to generate your temporary password. Save your generated password before following the next step to log in with that password.
             </li>
             <li>
-                <a href="https://cloud.gov/docs/getting-started/accounts/">Log in</a> with your generated temporary password, which will prompt you to reset your password.
+                After you log in, you can <a href="{{password.changeLink}}">change your password</a>.
             </li>
         </ol>
         </p>

--- a/uaaextras/templates/email/body.html
+++ b/uaaextras/templates/email/body.html
@@ -25,7 +25,7 @@
 	          <b>Read the documentation</b> - After you register and log in, review the <a href="https://cloud.gov/docs/getting-started/accounts/#use-your-account-responsibly">acceptable uses and rules of behavior</a>.
             </li>
             <li>
-            If you signed up for a trial account (a sandbox), <strong>make sure you understand the <a href="https://cloud.gov/overview/pricing/free-limited-sandbox/#to-keep-in-mind-before-you-try-your-sandbox"><strong>sandbox policies and restrictions</a></strong>. Note that sandbox content is wiped regularly. If this isn’t you, don’t worry about this and skip to ...
+            If you signed up for a trial space (a sandbox), <strong>make sure you understand the <a href="https://cloud.gov/overview/pricing/free-limited-sandbox/#to-keep-in-mind-before-you-try-your-sandbox"><strong>sandbox policies and restrictions</a></strong>.
             </li>
             <li>
             Then <a href="https://cloud.gov/docs/getting-started/setup/">set up your access and get started</a>.

--- a/uaaextras/templates/reset_password.html
+++ b/uaaextras/templates/reset_password.html
@@ -26,7 +26,7 @@
   {% if password %}
   <h2>Your temporary password</h2>
   <code>{{ password }}</code>
-  <p>Please login and <a href="{{ url_for('change_password') }}">reset your password</a>.</p>
+  <p>Please <a href="https://login.fr.cloud.gov/login">log in</a> and then <a href="{{ url_for('change_password') }}">reset your password</a>.</p>
   {% endif %}
   {% endif %}
 </div>

--- a/uaaextras/templates/reset_password.html
+++ b/uaaextras/templates/reset_password.html
@@ -26,7 +26,7 @@
   {% if password %}
   <h2>Your temporary password</h2>
   <code>{{ password }}</code>
-  <p>Please <a href="https://login.fr.cloud.gov/login">log in</a> and then <a href="{{ url_for('change_password') }}">reset your password</a>.</p>
+  <p>Please <a href="{{loginLink}}">log in</a> and then <a href="{{ url_for('change_password') }}">reset your password</a>.</p>
   {% endif %}
   {% endif %}
 </div>

--- a/uaaextras/tests.py
+++ b/uaaextras/tests.py
@@ -833,7 +833,11 @@ class TestAppConfig(unittest.TestCase):
             assert rv.status_code == 200
             redis_conn.get.assert_called_with('test@example.com')
             redis_conn.delete.assert_called_with('test@example.com')
-            render_template.assert_called_with('reset_password.html', password=generate_temporary_password())
+            render_template.assert_called_with(
+                'reset_password.html',
+                password=generate_temporary_password(),
+                loginLink=app.config['UAA_BASE_URL']
+            )
 
     @patch('uaaextras.webapp.render_template')
     @patch('uaaextras.webapp.flash')

--- a/uaaextras/webapp.py
+++ b/uaaextras/webapp.py
@@ -231,7 +231,8 @@ def do_expiring_pw_notifications(app, changeLink, start=1):
 
             password = {
                 'daysUntilExpiration': daysUntilExpiration,
-                'changeLink': changeLink
+                'changeLink': changeLink,
+                'loginLink': app.config['UAA_BASE_URL']
             }
             with app.app_context():
                 subject = render_template('email/subject-expiring-password.txt',
@@ -757,7 +758,11 @@ def create_app(env=os.environ):
                     temporaryPassword
                 ):
                     logging.info('Set temporary password for {0}'.format(email))
-                    return render_template('reset_password.html', password=temporaryPassword)
+                    return render_template(
+                        'reset_password.html',
+                        password=temporaryPassword,
+                        loginLink=app.config['UAA_BASE_URL']
+                    )
                 else:
                     flash('Unable to set temporary password. Did you use the right email address?')
                     return render_template('reset_password.html')


### PR DESCRIPTION
Multiple people have run into the following flow while trying to reset their password, including https://github.com/18F/cg-uaa/issues/42 and [this person](https://cloud-gov.zendesk.com/agent/tickets/418):

1. Go to https://account.fr.cloud.gov/forgot-password and fill it out.
2. Receive email.
3. Click "Verify your email address".
4. Put in email address, receive temporary password.
5. Click "Please login and reset your password." - which links to https://account.fr.cloud.gov/change-password but that page sends you to https://login.fr.cloud.gov/ since you aren't logged in yet.
6. Using https://login.fr.cloud.gov/, log in with temporary password.
7. Enter token code.
8. Land on https://login.fr.cloud.gov/ which only offers the options of "dashboard" and "invite users", instead of ending up at a page for changing password. The page for changing password is at https://account.fr.cloud.gov/change-password (and linked from https://account.fr.cloud.gov/), and you can use it if you go directly to that URL while you're logged in, but it's not linked on the page you end up at when you log in (https://login.fr.cloud.gov/).

I suspect it's not easy to do either of the following:
A. Update https://login.fr.cloud.gov/ to include a link to https://account.fr.cloud.gov/change-password (I think that comes from an upstream template?) - and it wouldn't really make sense for people with SSO accounts to see the change password link there. :/
B. If a person starts at https://account.fr.cloud.gov/change-password while logged out, send them back to that page after logging in.

So here's an alternate not-great-but-might-help way that we could make this make more sense for the people who are currently using the cloud.gov IDP (and sending confused support mail).

Changes:
* The email for "your password is expiring soon" now asks people to log in before visiting the change password link.
* Minor updates to new account email to remove confusing info about sandbox content getting wiped regularly, since that isn't happening yet.
* On reset password page, ask people to log in and then use the change password link.

I didn't see any examples of a more elegant way to link to the login page other than pasting in the login URL - not sure if there's a template variable available for that.