### PR TITLE
Pin to latest python minor version.

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.4.5
+python-3.6.x

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34,flake8,report
+envlist = py36,flake8,report
 
 [testenv]
 commands =


### PR DESCRIPTION
Python 3.4.5 isn't available in the latest buildpack.