### PR TITLE
Use deprecated features so we can deploy

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -12,7 +12,7 @@ jobs:
     input_mapping:
       cg-uaa-extras-app: uaa-extras-integrated
     file: cg-uaa-extras-app/ci/test.yml
-  - put: cloud-gov-development-uaaextras
+  - put: cloud-gov-development
     params:
       manifest: cg-uaa-extras-app/manifest_uaaextra.yml
       path: uaa-extras-integrated
@@ -30,7 +30,7 @@ jobs:
         BRANDING_COMPANY_NAME: {{branding-company-name-development}}
         IDP_PROVIDER_ORIGIN: {{idp-provider-origin-development}}
         IDP_PROVIDER_URL: {{idp-provider-url-development}}
-  - put: cloud-gov-development-invite
+  - put: cloud-gov-development
     params:
       manifest: cg-uaa-extras-app/manifest_invite.yml
       path: uaa-extras-integrated
@@ -79,7 +79,7 @@ jobs:
     input_mapping:
       cg-uaa-extras-app: uaa-extras-integrated
     file: cg-uaa-extras-app/ci/test.yml
-  - put: cloud-gov-staging-uaaextras
+  - put: cloud-gov-staging
     params:
       manifest: cg-uaa-extras-app/manifest_uaaextra.yml
       path: uaa-extras-integrated
@@ -97,7 +97,7 @@ jobs:
         BRANDING_COMPANY_NAME: {{branding-company-name-staging}}
         IDP_PROVIDER_ORIGIN: {{idp-provider-origin-staging}}
         IDP_PROVIDER_URL: {{idp-provider-url-staging}}
-  - put: cloud-gov-staging-invite 
+  - put: cloud-gov-staging
     params:
       manifest: cg-uaa-extras-app/manifest_invite.yml
       path: uaa-extras-integrated
@@ -147,7 +147,7 @@ jobs:
     input_mapping:
       cg-uaa-extras-app: uaa-extras-integrated
     file: cg-uaa-extras-app/ci/test.yml
-  - put: cloud-gov-production-uaaextra
+  - put: cloud-gov-production
     params:
       manifest: cg-uaa-extras-app/manifest_production_fr_uaaextra.yml
       path: uaa-extras-integrated
@@ -165,7 +165,7 @@ jobs:
         BRANDING_COMPANY_NAME: {{branding-company-name-production}}
         IDP_PROVIDER_ORIGIN: {{idp-provider-origin-production}}
         IDP_PROVIDER_URL: {{idp-provider-url-production}}
-  - put: cloud-gov-production-invite
+  - put: cloud-gov-production
     params:
       manifest: cg-uaa-extras-app/manifest_production_fr_invite.yml
       path: uaa-extras-integrated

--- a/manifest_invite.yml
+++ b/manifest_invite.yml
@@ -2,8 +2,7 @@
 applications:
 - name: invite
   host: invite
-  buildpack:
-  - staticfile_buildpack
+  buildpack: staticfile_buildpack
   stack: cflinuxfs3
   path: redirect
   memory: 64M

--- a/manifest_production.yml
+++ b/manifest_production.yml
@@ -3,8 +3,7 @@ applications:
 - name: invite
   no-hostname: true
   domain: invite.cloud.gov
-  buildpack:
-  - python_buildpack
+  buildpack: python_buildpack
   stack: cflinuxfs3
 env:
   ENV: production

--- a/manifest_production_fr_invite.yml
+++ b/manifest_production_fr_invite.yml
@@ -3,8 +3,7 @@ applications:
 - name: invite
   host: invite
   domain: fr.cloud.gov
-  buildpack:
-  - staticfile_buildpack
+  buildpack: staticfile_buildpack
   stack: cflinuxfs3
   path: redirect
   env:

--- a/manifest_production_fr_uaaextra.yml
+++ b/manifest_production_fr_uaaextra.yml
@@ -3,8 +3,7 @@ applications:
 - name: uaaextra
   host: account
   domain: fr.cloud.gov
-  buildpack:
-  - python_buildpack
+  buildpack: python_buildpack
   stack: cflinuxfs3
   instances: 2
   services:

--- a/manifest_uaaextra.yml
+++ b/manifest_uaaextra.yml
@@ -2,8 +2,7 @@
 applications:
 - name: uaaextra
   host: account
-  buildpacks:
-  - python_buildpack
+  buildpacks: python_buildpack
   stack: cflinuxfs3
   services:
   - redis-accounts


### PR DESCRIPTION
the cf plugin on concourse can't handle new features, so we'll have to put up with deprecation warnings.